### PR TITLE
refactor: parameterize comparison CLI and sample data fixtures

### DIFF
--- a/scripts/analysis/compare_recommendations.py
+++ b/scripts/analysis/compare_recommendations.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Canonical location: scripts/analysis/compare_recommendations.py
-# Expected inputs: config.toml, data/raw/ratings.csv, data/raw/watchlist.xlsx
+# Expected inputs: ratings CSV and watchlist CSV
 """
 Compare SVD vs ElasticNet recommendations side by side
 """
@@ -48,13 +48,14 @@ def run(
     print(f"Comparing top {topk} recommendations from both methods")
 
     svd_cmd = (
-        f"{sys.executable} -m imdb_recommender.cli recommend --config config.toml --topk {topk}"
+        f"{sys.executable} -m imdb_recommender.cli recommend "
+        f'--ratings "{ratings_file}" --watchlist "{watchlist_file}" --topk {topk}'
     )
     run_command(svd_cmd, "SVD Collaborative Filtering Recommendations")
 
     en_cmd = (
         f"{sys.executable} scripts/training/elasticnet_recommender.py "
-        f"--ratings-file {ratings_file} --watchlist-file {watchlist_file} --topk {topk}"
+        f'--ratings-file "{ratings_file}" --watchlist-file "{watchlist_file}" --topk {topk}'
     )
     run_command(en_cmd, "ElasticNet Feature Engineering Recommendations")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,6 @@
-import random
 import shutil
 from pathlib import Path
 
-import numpy as np
 import pytest
 
 
@@ -35,6 +33,8 @@ def sample_watchlist_path(tmp_data_dir) -> Path:
 def _force_seed(monkeypatch):
     monkeypatch.setenv("PYTHONHASHSEED", "0")
     try:
+        import numpy as np, random  # noqa: E401,I001
+
         np.random.seed(1234)
         random.seed(1234)
     except Exception:

--- a/tests/fixtures_ratings.csv
+++ b/tests/fixtures_ratings.csv
@@ -1,2 +1,0 @@
-const,Your Rating,Created,Title,Year,Genres,IMDb Rating,Num Votes
-tt0111161,10,2024-06-01,The Shawshank Redemption,1994,Drama,9.3,2900000

--- a/tests/fixtures_watchlist.csv
+++ b/tests/fixtures_watchlist.csv
@@ -1,2 +1,0 @@
-Const,Created,Title,Year,Genres,IMDb Rating,Num Votes
-tt0480249,2020-01-01,The Simpsons Movie,2007,Animation,Adventure,Comedy,7.3,400000


### PR DESCRIPTION
## Summary
- add reusable sample CSV fixtures and deterministic seed
- harden comparison CLI to require explicit ratings and watchlist files
- remove legacy test fixtures referencing personal data

## Testing
- `ruff check scripts/analysis/compare_recommendations.py tests/conftest.py scripts/training/run_elasticnet_cv.py scripts/training/elasticnet_recommender.py`
- `black scripts/analysis/compare_recommendations.py tests/conftest.py`
- `pytest -q --cov=imdb_recommender`


------
https://chatgpt.com/codex/tasks/task_e_68a68c8752a08332a901ea48e09d16bb