### PR TITLE
feat: add content-type filtering

### DIFF
--- a/src/imdb_recommender/pipeline.py
+++ b/src/imdb_recommender/pipeline.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pandas as pd
+
+MOVIE_TYPES = {"movie", "short"}
+TV_TYPES = {"tvSeries", "tvMiniSeries", "tvMovie", "tvSpecial"}
+
+
+def filter_by_content_type(df: pd.DataFrame, content_type: str) -> pd.DataFrame:
+    """Filter a recommendations dataframe by content type.
+
+    Parameters
+    ----------
+    df:
+        DataFrame containing a ``titleType`` column.
+    content_type:
+        One of ``{"all", "movies", "tv"}``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Filtered dataframe.
+
+    Raises
+    ------
+    ValueError
+        If ``content_type`` is not recognised or the required column is
+        missing when a filter other than ``"all"`` is requested.
+    """
+    if content_type == "all":
+        return df
+
+    if "titleType" not in df.columns:
+        raise ValueError("titleType metadata required for content-type filtering.")
+
+    if content_type == "movies":
+        return df[df["titleType"].isin(MOVIE_TYPES)]
+    if content_type == "tv":
+        return df[df["titleType"].isin(TV_TYPES)]
+
+    raise ValueError(f"Unknown content_type: {content_type}")

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1,0 +1,125 @@
+import pandas as pd
+from typer.testing import CliRunner
+
+from imdb_recommender.cli import app
+from imdb_recommender.data_io import Dataset, IngestResult
+from imdb_recommender.schemas import Recommendation
+
+runner = CliRunner()
+
+
+def _patched_ingest(monkeypatch, include_title_type: bool = True):
+    data = {
+        "imdb_const": ["m1", "t1"],
+        "title": ["Movie1", "TV1"],
+        "year": [2000, 2001],
+        "genres": ["Drama", "Sport"],
+    }
+    if include_title_type:
+        data["title_type"] = ["movie", "tvSeries"]
+    watch = pd.DataFrame(data)
+    ratings = watch.iloc[0:0].copy()
+    ds = Dataset(ratings=ratings, watchlist=watch)
+    ingest_res = IngestResult(dataset=ds, warnings=[])
+    monkeypatch.setattr("imdb_recommender.cli.ingest_sources", lambda *a, **k: ingest_res)
+
+    def fake_score(self, seeds, uw, gw, recency, exclude_rated):
+        return {"m1": 0.1, "t1": 0.2}, {}
+
+    monkeypatch.setattr("imdb_recommender.cli.SVDAutoRecommender.score", fake_score)
+
+    def fake_top_n(self, blended, dataset, topk, explanations=None, exclude_rated=True):
+        items = sorted(blended.items(), key=lambda x: x[1], reverse=True)
+        cat = dataset.catalog.set_index("imdb_const")
+        out = []
+        for cid, score in items[:topk]:
+            row = cat.loc[cid]
+            out.append(
+                Recommendation(
+                    imdb_const=cid,
+                    title=row.get("title"),
+                    year=row.get("year"),
+                    genres=row.get("genres"),
+                    score=score,
+                    why_explainer="",
+                )
+            )
+        return out
+
+    monkeypatch.setattr("imdb_recommender.cli.Ranker.top_n", fake_top_n)
+
+
+def test_cli_recommend_movies_only_returns_no_tv(monkeypatch):
+    _patched_ingest(monkeypatch)
+    result = runner.invoke(
+        app,
+        [
+            "recommend",
+            "--ratings",
+            "r.csv",
+            "--watchlist",
+            "w.csv",
+            "--content-type",
+            "movies",
+            "--no-exclude-rated",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Movie1" in result.stdout
+    assert "TV1" not in result.stdout
+
+
+def test_cli_recommend_tv_only_returns_no_movies(monkeypatch):
+    _patched_ingest(monkeypatch)
+    result = runner.invoke(
+        app,
+        [
+            "recommend",
+            "--ratings",
+            "r.csv",
+            "--watchlist",
+            "w.csv",
+            "--content-type",
+            "tv",
+            "--no-exclude-rated",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "TV1" in result.stdout
+    assert "Movie1" not in result.stdout
+
+
+def test_cli_default_all_includes_both_when_present(monkeypatch):
+    _patched_ingest(monkeypatch)
+    result = runner.invoke(
+        app,
+        [
+            "recommend",
+            "--ratings",
+            "r.csv",
+            "--watchlist",
+            "w.csv",
+            "--no-exclude-rated",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "TV1" in result.stdout and "Movie1" in result.stdout
+
+
+def test_graceful_when_metadata_missing(monkeypatch):
+    _patched_ingest(monkeypatch, include_title_type=False)
+    result = runner.invoke(
+        app,
+        [
+            "recommend",
+            "--ratings",
+            "r.csv",
+            "--watchlist",
+            "w.csv",
+            "--content-type",
+            "movies",
+            "--no-exclude-rated",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "titleType metadata required" in result.stderr

--- a/tests/unit/test_filtering.py
+++ b/tests/unit/test_filtering.py
@@ -1,0 +1,51 @@
+import pandas as pd
+import pytest
+
+from imdb_recommender.pipeline import filter_by_content_type
+
+
+def _build_mixed_df():
+    return pd.DataFrame(
+        {
+            "imdb_const": ["m1", "t1", "s1"],
+            "titleType": ["movie", "tvSeries", "short"],
+            "score": [0.9, 0.8, 0.7],
+        }
+    )
+
+
+def test_only_movies_returns_movies():
+    df = _build_mixed_df()
+    out = filter_by_content_type(df, "movies")
+    assert set(out["titleType"]) <= {"movie", "short"}
+
+
+def test_only_tv_returns_tv():
+    df = _build_mixed_df()
+    out = filter_by_content_type(df, "tv")
+    assert set(out["titleType"]) <= {"tvSeries", "tvMiniSeries", "tvMovie", "tvSpecial"}
+
+
+def test_all_returns_all():
+    df = _build_mixed_df()
+    out = filter_by_content_type(df, "all")
+    assert len(out) == len(df)
+
+
+def test_filter_applied_after_ranking():
+    df = pd.DataFrame(
+        {
+            "imdb_const": ["tv1", "mov1"],
+            "titleType": ["tvSeries", "movie"],
+            "score": [1.0, 0.5],
+        }
+    )
+    df = df.sort_values("score", ascending=False)
+    filtered = filter_by_content_type(df, "movies").head(1)
+    assert filtered.iloc[0]["imdb_const"] == "mov1"
+
+
+def test_missing_metadata_raises():
+    df = pd.DataFrame({"imdb_const": ["m1"], "score": [0.9]})
+    with pytest.raises(ValueError):
+        filter_by_content_type(df, "movies")


### PR DESCRIPTION
## Summary
- add enum-based `--content-type` option to CLI and filter results post-ranking
- provide `filter_by_content_type` utility for movies, tv, or all
- test CLI filtering modes and metadata-missing handling

## Testing
- `ruff check src/imdb_recommender/cli.py src/imdb_recommender/pipeline.py tests/unit/test_filtering.py tests/integration/test_cli.py`
- `pytest tests/unit/test_filtering.py tests/integration/test_cli.py -q --cov=imdb_recommender`


------
https://chatgpt.com/codex/tasks/task_e_68a6978e16b88332ba1b8f4745ce094c