### PR TITLE
Align packaging metadata and CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e ".[test]"
-        pip install diff-cover
 
     - name: Run tests
       run: |

--- a/README.md
+++ b/README.md
@@ -47,11 +47,8 @@ A comprehensive movie and TV show recommendation system that learns your persona
 git clone https://github.com/brentianpalmer/imdb-recommender.git
 cd imdb-recommender
 
-# Install package
-pip install -e .
-
-# Install ML dependencies
-pip install scikit-learn
+# Install package with optional ML dependencies
+pip install -e ".[all]"
 ```
 
 ### Data Setup

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -31,10 +31,9 @@ application loads environment variables via `python-dotenv` when scripts run.
 - `ruff check src tests` – style and static checks
 - `black --check src tests` – ensure formatting
 - `pytest --cov=imdb_recommender --cov-report=xml --cov-fail-under=85` – run tests with coverage
-- Optional changed-lines coverage using diff-cover:
+- Optional changed-lines coverage using diff-cover (installed via test extras):
 ```
 pytest --cov=imdb_recommender --cov-report=xml --cov-fail-under=85
-pip install diff-cover
 diff-cover coverage.xml --compare-branch=origin/main --fail-under=85
 ```
 
@@ -42,7 +41,7 @@ diff-cover coverage.xml --compare-branch=origin/main --fail-under=85
 Never commit real datasets. Use fixtures under `tests/fixtures/data/*`.
 ```
 # Use synthetic samples; pass paths explicitly
-python scripts/training/run_elasticnet_cv.py \
+imdbrec recommend \
   --ratings-file tests/fixtures/data/ratings_sample.csv \
   --watchlist-file tests/fixtures/data/watchlist_sample.csv \
   --topk 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
 test = [
   "pytest>=8.0.0",
   "pytest-cov>=4.1.0",
+  "diff-cover>=9.0.0",
   "hypothesis>=6.82.0",
   "selenium>=4.15.0",
   "webdriver-manager>=4.0.0",

--- a/src/imdb_recommender/__main__.py
+++ b/src/imdb_recommender/__main__.py
@@ -1,0 +1,4 @@
+from .cli import app
+
+if __name__ == "__main__":
+    app()

--- a/src/imdb_recommender/cli.py
+++ b/src/imdb_recommender/cli.py
@@ -8,11 +8,11 @@ import typer
 
 from .config import AppConfig
 from .data_io import ingest_sources
-
-# from .hyperparameter_tuning import HyperparameterTuningPipeline  # Temporarily disabled
-from .utils import filter_by_content_type
 from .ranker import Ranker
 from .recommender_svd import SVDAutoRecommender
+from .utils import filter_by_content_type
+
+# from .hyperparameter_tuning import HyperparameterTuningPipeline  # Temporarily disabled
 
 app = typer.Typer(help="SVD-Powered IMDb Movie Recommender")
 


### PR DESCRIPTION
## Summary
- include diff-cover in test extras and expose imdbrec console script
- document cli usage and diff-cover extras
- allow `python -m imdb_recommender` entrypoint and streamline CI

## Testing
- `ruff check .`
- `black --check .`
- `pytest --cov=imdb_recommender --cov-report=xml --cov-fail-under=85` *(fails: Required test coverage of 85% not reached. Total coverage: 49.57%)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a770a6aa808332acba2de315a4b2de